### PR TITLE
docs: Add dark mode image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # WikiORA - Gene Over-Representation Analysis
 
-![WikiORA Example Workflow](https://wikiora.toolforge.org/static/example.png)
+![WikiORA Example Workflow](https://wikiora.toolforge.org/static/example.png#gh-light-mode-only)
+![WikiORA Example Workflow](https://i.imgur.com/mwU0BbL.png#gh-dark-mode-only)
 
 WikiORA is a tool designed to simplify the process of gene set over-representation analysis by integrating data from Wikidata and Wikipedia. Our aim is to provide an easy-to-use platform for researchers to identify significantly enriched gene sets in their data, using a combination of curated gene sets from various sources.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # WikiORA - Gene Over-Representation Analysis
 
-![WikiORA Example Workflow](https://wikiora.toolforge.org/static/example.png#gh-light-mode-only)
-![WikiORA Example Workflow](https://i.imgur.com/mwU0BbL.png#gh-dark-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://i.imgur.com/mwU0BbL.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://wikiora.toolforge.org/static/example.png">
+  <img alt="WikiORA Example Workflow" src="https://wikiora.toolforge.org/static/example.png">
+</picture>
 
 WikiORA is a tool designed to simplify the process of gene set over-representation analysis by integrating data from Wikidata and Wikipedia. Our aim is to provide an easy-to-use platform for researchers to identify significantly enriched gene sets in their data, using a combination of curated gene sets from various sources.
 


### PR DESCRIPTION
Não é possível ver a imagem corretamente se você estiver usando github no dark mode (ou high contrast, que é o meu caso):

![image](https://github.com/user-attachments/assets/7bf926d7-c612-41db-9d3b-07781c6010ce)

Essa PR faz com que a imagem renderizada mude se vc estiver usando dark mode vs light mode.